### PR TITLE
fix: enable Video playback in AppImage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad
 
       - name: install frontend dependencies
         run: npm install # change this to npm, pnpm or bun depending on which one you use.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad
 
       - name: install frontend dependencies
         run: npm install # change this to npm, pnpm or bun depending on which one you use.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,9 @@
     "linux": {
       "deb": {
         "depends": []
+      },
+      "appimage": {
+        "bundleMediaFramework": true
       }
     }
   },


### PR DESCRIPTION
* set `bundleMediaFramework` for AppImage build in tauri.conf
* install `gstreamer1.0-plugins-bad` and `gstreamer1.0-plugins-ugly` on the build host

`bundleMediaFramework` essentially just executes `linuxdeploy-plugin-gstreamer`, which just copies all `gstreamer` files from the build host to the `app.AppDir` directory, which is then compressed into the AppImage. Therefore we need the codecs on the build host to get them into the AppImage.

`gstreamer1.0-plugins-bad` is required for H.264 decoding using `libgstx264.so`, while `gstreamer1.0-plugins-ugly` seems to be required for `libgsthls.so` and/or `libgstmpegtsdemux.so`.

---

Considerations:
As you can imagine, installing both those libraries and linuxdeploy simply copying *everything* unfortunately bloats the AppImage quite a bit.

I actually ran a build without `-ugly` and I was still able to still play the video, presumably because `-bad` ships with OpenH264 support. On the one hand `-bad` plugins are potentially not as stable as `-ugly`, but on the other we require `-bad` anyway because of of HLS/MPEGTS (my build without `-bad` would still not play any videos).

For comparison in sizes:
| Build  | Size |
| ------------- | ------------- |
| Current | 78.3 MB |
| `bundleMediaFramework` | 89.9 MB |
| `bMF` + `-ugly` | 91.3 MB |
| `bMF` + `-ugly` + `-bad` | 127 MB |
| `bMF` + `-bad` | 126 MB |

All builds are on [my Releases](https://github.com/mihawk90/segment-editor/releases).

So yeah... the biggest increase is obviously the `-bad` plugins, which make the `-ugly` ones almost negligible...

But whether you want both or just the `-bad` plugins is up to you, I can remove the `-ugly` package if you like.

---

Fixes #7 